### PR TITLE
Add API for passing in overriding `sdkPath`

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -110,11 +110,15 @@ class CommandLineOptions {
   /// Skip package dependency install checks.
   bool skipInstall;
 
+  /// Set a custom SDK location.
+  String? sdk;
+
   CommandLineOptions({
     this.verbose = false,
     this.color = false,
     this.forceInstall = false,
     this.skipInstall = false,
+    this.sdk,
   });
 
   CommandLineOptions.fromArgs(ArgResults args)
@@ -123,6 +127,7 @@ class CommandLineOptions {
           color: args['color'],
           forceInstall: args['force-install'],
           skipInstall: args['skip-install'],
+          sdk: args['sdk'],
         );
 }
 

--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -64,28 +64,26 @@ class Driver {
 
   bool silent = false;
 
-  final String? sdkPath;
+  String? sdkPath;
 
   /// Handles printing.  Can be overwritten by clients.
   Logger logger = Logger.standard();
 
-  Driver(
-    ArgResults argResults, {
-    this.sdkPath,
-  })  : options = CommandLineOptions.fromArgs(argResults),
+  Driver(ArgResults argResults)
+      : options = CommandLineOptions.fromArgs(argResults),
         sources = argResults.rest
             .map((p) => path.normalize(io.File(p).absolute.path))
-            .toList();
+            .toList() {
+    sdkPath = options.sdk;
+  }
 
-  factory Driver.forArgs(
-    List<String> args, {
-    String? sdkPath,
-  }) {
+  factory Driver.forArgs(List<String> args) {
     var argParser = ArgParser()
       ..addFlag('verbose', abbr: 'v', help: 'verbose output.')
       ..addFlag('force-install', help: 'force package (re)installation.')
       ..addFlag('skip-install', help: 'skip package install checks.')
-      ..addFlag('color', help: 'color output.');
+      ..addFlag('color', help: 'color output.')
+      ..addOption('sdk', help: 'set a custom SDK path');
     var argResults = argParser.parse(args);
     return Driver(argResults);
   }


### PR DESCRIPTION
Fixes: #29.

Will update to use `AnalysisContextColllection` when API is available (see: https://dart-review.googlesource.com/c/sdk/+/194324).

/cc @scheglov @bwilkerson 